### PR TITLE
Add memory cleanup to silence valgrind if running hthread with memchecker

### DIFF
--- a/src/hthread.c
+++ b/src/hthread.c
@@ -1482,4 +1482,24 @@ found_cv:
 	return 0;
 }
 
+static void __attribute__ ((constructor)) hthread_init (void)
+{
+}
+
+static void __attribute__ ((destructor)) hthread_fini (void)
+{
+	struct hthread *th;
+	struct hthread *nth;
+	hthread_lock();
+	if (hthreads != NULL) {
+		HASH_ITER(hh, hthreads, th, nth) {
+			HASH_DEL(hthreads, th);
+		}
+	}
+	if (hthread_root != NULL) {
+		free(hthread_root);
+	}
+	hthread_unlock();
+}
+
 #endif


### PR DESCRIPTION
It works for successful threading, for failure scenarios memory will still be lost...

$ valgrind --leak-check=full --show-reachable=yes ./success-00-debug
==26320== Memcheck, a memory error detector
==26320== Copyright (C) 2002-2011, and GNU GPL'd, by Julian Seward et al.
==26320== Using Valgrind-3.7.0 and LibVEX; rerun with -h for copyright info
==26320== Command: ./success-00-debug
==26320==
(hthread:26320) injected thread: root-process (0x42210c0)
==26320==
==26320== HEAP SUMMARY:
==26320==     in use at exit: 497 bytes in 3 blocks
==26320==   total heap usage: 6 allocs, 3 frees, 1,025 bytes allocated
==26320==
==26320== 44 bytes in 1 blocks are still reachable in loss record 1 of 3
==26320==    at 0x402CE68: malloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==26320==    by 0x804BDF3: hthread_add_actual (hthread.c:223)
==26320==    by 0x804C10E: hthread_add_root (hthread.c:280)
==26320==    by 0x8053475: hthread_mutex_init_actual_debug (hthread.c:302)
==26320==    by 0x8048C32: main (success-00.c:22)
==26320==
==26320== 69 bytes in 1 blocks are still reachable in loss record 2 of 3
==26320==    at 0x402CE68: malloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==26320==    by 0x804C0BF: hthread_add_root (hthread.c:269)
==26320==    by 0x8053475: hthread_mutex_init_actual_debug (hthread.c:302)
==26320==    by 0x8048C32: main (success-00.c:22)
==26320==
==26320== 384 bytes in 1 blocks are still reachable in loss record 3 of 3
==26320==    at 0x402CE68: malloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==26320==    by 0x804BE3E: hthread_add_actual (hthread.c:223)
==26320==    by 0x804C10E: hthread_add_root (hthread.c:280)
==26320==    by 0x8053475: hthread_mutex_init_actual_debug (hthread.c:302)
==26320==    by 0x8048C32: main (success-00.c:22)
==26320==
==26320== LEAK SUMMARY:
==26320==    definitely lost: 0 bytes in 0 blocks
==26320==    indirectly lost: 0 bytes in 0 blocks
==26320==      possibly lost: 0 bytes in 0 blocks
==26320==    still reachable: 497 bytes in 3 blocks
==26320==         suppressed: 0 bytes in 0 blocks
==26320==
==26320== For counts of detected and suppressed errors, rerun with: -v
==26320== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
